### PR TITLE
Fix for the issue in the mm macros: Two .LI in one doc don't work

### DIFF
--- a/tmac/tmac.m
+++ b/tmac/tmac.m
@@ -616,7 +616,7 @@
 ..
 .de )B
 .br
-.nr :g -1
+.nr :g -1 1
 .)C nr :a ]a \\*(]a
 .)C nr :b ]b \\*(]b
 'in \\n(:bu


### PR DESCRIPTION
This pull request fixes the issue of being not able to have more than one .BL/.LI/.LE definition in a document when using
the mm macros.
Resolving this reveals another issue with lists on which I am currently working.
