### PR TITLE
Turn no-space mode off when calling `.EPS`

### DIFF
--- a/tmac/tmac.eps
+++ b/tmac/tmac.eps
@@ -25,6 +25,7 @@
 .	if '\\$2'R' .nr eps.in (\\n(.l-\\n(.i-\\n[eps.w])
 .	\" printing the image
 .	br
+.	rs
 .	ne \\n[eps.h]u
 .	sp \\n[eps.h]u
 .	ie '\\$0'.PDF' \h'|\\n[eps.in]u'\\X'pdf "\\$1" \\n[eps.w]'\h'\\n[eps.w]u'


### PR DESCRIPTION
This fixes issues when working with other macros such as ms and men
since they enable no-space mode during their traps for headers. The eps
file is not given enough space if it is on the first line of a new
page.

```sh
roff -meps -men test.ms | post > test.ps
```
```roff
.\" test.ms
.EPS test.eps
.bp
.EPS test.eps
```
Causes the following to happen on the 2nd page
![2021-03-25_17:35:31](https://user-images.githubusercontent.com/34443260/112560506-fe8b0080-8d98-11eb-85eb-362cddc7b636.png)
This fix results in
![2021-03-25_17:35:11](https://user-images.githubusercontent.com/34443260/112560533-0ea2e000-8d99-11eb-80b6-6b859a7c7dd4.png)