### PR TITLE
tmac/NOTICE: Change Lucent License to MIT.

### DIFF
--- a/tmac/NOTICE
+++ b/tmac/NOTICE
@@ -4,7 +4,7 @@ and the files used by them, like me/*:
   Copyright (C) 2003, Lucent Technologies Inc. and others. All Rights Reserved.
 
   The original code as distributed in Plan 9 operating system by Lucent
-  and its modifications are under Lucent Public License, Version 1.02.
+  and its modifications are under the MIT license.
 
 For everything else:
 


### PR DESCRIPTION
As explained before, all the Plan9 code was relicensed to MIT, so we should change that here aswell!